### PR TITLE
Fix new app creation path

### DIFF
--- a/AP/public/manage_apps.php
+++ b/AP/public/manage_apps.php
@@ -25,9 +25,16 @@ if (isset($_POST['new_app']) && trim($_POST['new_app'])) {
     $ins = $pdo->prepare("INSERT INTO apps (name, slug, enabled) VALUES (:n, :s, 0)");
     $ins->execute(['n' => $name, 's' => $slug]);
     // Optionally create placeholder file
-    $filePath = __DIR__ . "/app/{$slug}.php";
+    $appDir = __DIR__ . '/app';
+    if (!is_dir($appDir)) {
+        mkdir($appDir, 0777, true);
+    }
+    $filePath = $appDir . "/{$slug}.php";
     if (!file_exists($filePath)) {
-        file_put_contents($filePath, "<?php\n// Pagina per {$name}\necho '<h1>{$name}</h1>';\n");
+        file_put_contents(
+            $filePath,
+            "<?php\n// Pagina per {$name}\necho '<h1>{$name}</h1>';\n"
+        );
     }
     header('Location: manage_apps.php');
     exit;


### PR DESCRIPTION
## Summary
- handle missing `app` directory when creating new apps

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685aba39f228832db63b39d1cedc4215