### PR TITLE
Fix new app creation path

### DIFF
--- a/AP/public/assets/css/style.css
+++ b/AP/public/assets/css/style.css
@@ -27,6 +27,7 @@ body::before {
   background: radial-gradient(circle at center, rgba(255,45,149,.2), transparent 70%);
   animation: rotateBg 20s linear infinite;
   z-index:0;
+  pointer-events:none;
 }
 @keyframes rotateBg {
   from { transform: rotate(0deg); }
@@ -124,6 +125,7 @@ body::before {
   width: 100%; height: 100%;
   background: var(--gradient);
   opacity: 0.1;
+  pointer-events: none;
   transition: opacity 0.3s ease;
 }
 

--- a/AP/public/manage_apps.php
+++ b/AP/public/manage_apps.php
@@ -25,9 +25,16 @@ if (isset($_POST['new_app']) && trim($_POST['new_app'])) {
     $ins = $pdo->prepare("INSERT INTO apps (name, slug, enabled) VALUES (:n, :s, 0)");
     $ins->execute(['n' => $name, 's' => $slug]);
     // Optionally create placeholder file
-    $filePath = __DIR__ . "/app/{$slug}.php";
+    $appDir = __DIR__ . '/app';
+    if (!is_dir($appDir)) {
+        mkdir($appDir, 0777, true);
+    }
+    $filePath = $appDir . "/{$slug}.php";
     if (!file_exists($filePath)) {
-        file_put_contents($filePath, "<?php\n// Pagina per {$name}\necho '<h1>{$name}</h1>';\n");
+        file_put_contents(
+            $filePath,
+            "<?php\n// Pagina per {$name}\necho '<h1>{$name}</h1>';\n"
+        );
     }
     header('Location: manage_apps.php');
     exit;


### PR DESCRIPTION
## Summary
- handle missing `app` directory when creating new apps
- fix background overlay blocking manage app buttons

## Testing
- `php -l AP/public/manage_apps.php` *(fails: command not found)*
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_685aba39f228832db63b39d1cedc4215